### PR TITLE
Change calling functions in mutations loop

### DIFF
--- a/main.js
+++ b/main.js
@@ -221,8 +221,10 @@ fetch(urlRequestTransfers).then(function (response) {
  */
 
 // Event handler when the dropdown menu is clicked.  Calls: handleProfileDropdownClick for modifications.
-function modifyUserElement() {
-    const usermenuDropdown = document.querySelector('.DropdownMenu.Header__usermenu');
+function modifyUserElement(usermenuDropdown = null) {
+    if (!usermenuDropdown) {
+        usermenuDropdown = document.querySelector('.DropdownMenu.Header__usermenu');
+    }
     if ( usermenuDropdown ) {
         usermenuDropdown.addEventListener('click', handleProfileDropdownClick);
     }
@@ -237,18 +239,18 @@ function observeDropdownCreation() {
         observer = new MutationObserver((mutations) => {
             for (let mutation of mutations) {
                 if (mutation.type === 'childList') {
-                    // logout -> login
-                    const dropdown = parentElement.querySelector('.DropdownMenu.Header__usermenu');
-                    if (dropdown) {
-                        highLight();
-                        modifyUserElement();  // Click handler to add voting power to dropdown menu.
-                        // Optionally, disconnect the observer if you don't need it anymore
-                        // observer.disconnect();
-                    } else {
-                        highLight();
+                    for (let node of mutation.addedNodes) {
+                        if (node.matches && node.matches('.DropdownMenu.Header__usermenu')) {
+                            // logout -> login
+                            modifyUserElement(node);  // Click handler to add voting power to dropdown menu.
+                            // Optionally, disconnect the observer if you don't need it anymore
+                            // observer.disconnect();
+                            return; // Exit the loop after handling the dropdown
+                        }
                     }
                 }
             }
+            highLight();
         });
         const config = { childList: true, subtree: true };
         observer.observe(parentElement, config);

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,6 @@
   "host_permissions": [
     "https://sds.steemworld.org/*",
     "https://api.moecki.online/*",
-    "https://api2.moecki.online/*",
     "https://api.steemit.com/*"
   ]
 }


### PR DESCRIPTION
I made some minor modifications:
- to prevent unnecessary running of `modifyUserElement`,
- to pass the `DropdownMenuElement` to prevent double searches,
- to prevent running `highLight` on every mutated element.