### PR TITLE
feat: add follow status tooltips and bump version to v0.6.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.5-beta] - 2026-05-02
+## [0.6.0-beta] - 2026-05-31
+### Added
+- Follow status tooltips: Hovering over any user link now shows if they follow the logged-in user.
+- 10-minute caching for follow status to optimize performance.
 
+## [0.5.5-beta] - 2026-05-02
 ### Fixed
 - Eliminated duplicate accounts from "feed reach" and "price per feed" calculations using unique account sets and SDS API.
 - Fixed data bleed-through issue where post-payout data persisted on repurposed DOM nodes when navigating between feeds.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Specifically, it highlights posts that are promoted by burning Steem Dollars (SB
 - Enables toggling of resteem visibility
 - Displays voting power in the Profile menu
 - Provides a curator overlay in Steem feeds with information about a post, author, and the author's follower network.
+- Displays follow status (whether a user follows you) as a tooltip when hovering over account links.
 - Provides additional detailed information and visuals inside the Steem post page
 - Works on Steemit.com and other Steem-based sites using the Condenser front end.
 
@@ -104,6 +105,7 @@ Once installed, the extension will automatically highlight the relevant posts on
 - Look for the toggle option near the top/center-left of the page to control resteem visibility.
 - Your available voting power will appear in the profile dropdown menu near the top-right of the page.
 - Hover over the "Curation Info" label in feeds to see the curator overlay.
+- Hover over any user account link to see a tooltip indicating if that account follows you.
 
 ## Contributing
 

--- a/main.js
+++ b/main.js
@@ -17,6 +17,10 @@ let USER_LANGUAGE;
 const vpCache = new Map();
 const VP_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
+// Cache for follow status (10 minute TTL)
+const followCache = new Map();
+const FOLLOW_CACHE_TTL = 10 * 60 * 1000;
+
 /*
  *  The main logic is in highLight() and handleProfileDropdownClick()
  * o highlight()
@@ -234,6 +238,54 @@ function getAddress(elem) {
     return link ? link : null;
 }
 
+/**
+ * Checks if the target user follows the logged-in user via Steem API.
+ * Results are cached to minimize network overhead.
+ */
+async function checkFollowsMe(targetUser, currentUser) {
+    const cacheKey = `${targetUser}_follows_${currentUser}`;
+    const cached = followCache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < FOLLOW_CACHE_TTL) return cached.value;
+
+    try {
+        const data = await fetchProxy(steemApi, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'condenser_api.get_following',
+                params: [targetUser, currentUser, 'blog', 1],
+                id: 1
+            })
+        });
+        const follows = data?.result?.[0]?.following === currentUser;
+        followCache.set(cacheKey, { value: follows, timestamp: Date.now() });
+        return follows;
+    } catch (e) { return null; }
+}
+
+/**
+ * Attaches listeners to user links to display follow status on hover.
+ */
+function initFollowStatusHandlers() {
+    const currentUser = getUsername();
+    if (!currentUser) return;
+
+    const userLinks = document.querySelectorAll('a[href^="/@"]:not([data-sce-follow])');
+    userLinks.forEach(link => {
+        const targetUser = link.getAttribute('href').split('/@')[1]?.split('/')[0];
+        if (!targetUser || targetUser === currentUser) return;
+
+        link.setAttribute('data-sce-follow', 'observed');
+        link.addEventListener('mouseenter', async () => {
+            const follows = await checkFollowsMe(targetUser, currentUser);
+            if (follows === null) return;
+            const statusText = follows ? "follows you" : "does not follow you";
+            link.title = (link.title ? link.title + " \n" : "") + `@${targetUser} ${statusText}`;
+        }, { once: true });
+    });
+}
+
 /*
  * Network queries
  */
@@ -367,6 +419,7 @@ const runOncePerBatch = () => {
             updatePayoutValue();
         }
 
+        initFollowStatusHandlers();
         addUserVpRing_silent();
 
         // Re-initialize post features when on a post page (handles React re-renders from language/theme changes)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "version": "0.5.5",
-  "version_name": "0.5.5 Beta",
+  "version": "0.6.0",
+  "version_name": "0.6.0 Beta",
   "name": "Steem Curation Extension",
   "description": "Provide supplemental information for curators on Steem/Condenser based web sites.",
   "icons": { 


### PR DESCRIPTION
- Implemented hover-based follow status tooltips for user links.
- Integrated Steem API (condenser_api.get_following) to verify user relationships.
- Added a 10-minute caching mechanism for follow status to optimize performance.
- Updated README.md and CHANGELOG.md with new feature details.
- Bumped extension version to 0.6.0-beta in manifest.json.