### PR TITLE
fix: tooltip persistence, positioning, and targeting refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1-beta] - 2026-06-02
+### Fixed
+- Resolved an issue where the follower analysis tooltip could become "stuck" and remain visible after the mouse moved away from the link.
+- Improved tooltip overflow logic by using dynamic dimensions instead of hardcoded values, ensuring better placement at screen edges.
+
+### Changed
+- Refined tooltip targeting: now specifically triggers on post authors, comment authors, and "@-mentions" in post bodies, preventing the overlay from appearing on non-essential account links (like voter lists or sidebars).
+
 ## [0.7.0-beta] - 2026-06-01
 ### Added
 - Enhanced follower analysis tooltips: Hovering over any user link now shows total followers, 90-day active count, median reputation, and median reputation of active followers.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Specifically, it highlights posts that are promoted by burning Steem Dollars (SB
 - Enables toggling of resteem visibility
 - Displays voting power in the Profile menu
 - Provides a curator overlay in Steem feeds with information about a post, author, and the author's follower network.
-- Displays enhanced follow status and follower analysis (count, 90-day activity, and median reputations) as a dynamic tooltip when hovering over account links.
+- Displays enhanced follow status and follower analysis (count, 90-day activity, and median reputations) as a dynamic tooltip when hovering over post authors, comment authors, or user mentions.
 - Provides additional detailed information and visuals inside the Steem post page
 - Works on Steemit.com and other Steem-based sites using the Condenser front end.
 
@@ -105,7 +105,7 @@ Once installed, the extension will automatically highlight the relevant posts on
 - Look for the toggle option near the top/center-left of the page to control resteem visibility.
 - Your available voting power will appear in the profile dropdown menu near the top-right of the page.
 - Hover over the "Curation Info" label in feeds to see the curator overlay.
-- Hover over any user account link to see a dynamic tooltip with follow status and detailed follower statistics.
+- Hover over a post author, comment author, or user mention to see a dynamic tooltip with follow status and detailed follower statistics.
 
 ## Contributing
 

--- a/main.js
+++ b/main.js
@@ -355,7 +355,16 @@ function initFollowStatusHandlers() {
     if (!currentUser) return;
     injectTooltipStyles();
 
-    const userLinks = document.querySelectorAll('a[href^="/@"]:not([data-sce-follow])');
+    // Target only links that refer to post or comment authors
+    const selectors = [
+        '.user__name a[href^="/@"]',          // Feeds
+        '.Author a[href^="/@"]',             // Post headers
+        '.Comment__header-user a[href^="/@"]', // Comments
+        '.MarkdownViewer a[href^="/@"]',      // Mentions in post/comment body
+        '.entry-content a[href^="/@"]'       // Alternative body selector
+    ];
+    const userLinks = document.querySelectorAll(selectors.map(s => `${s}:not([data-sce-follow])`).join(', '));
+
     userLinks.forEach(link => {
         const targetUser = link.getAttribute('href').split('/@')[1]?.split('/')[0];
         if (!targetUser) return;
@@ -380,9 +389,14 @@ function initFollowStatusHandlers() {
 
         link.addEventListener('mousemove', updateTooltipPosition);
 
-        link.addEventListener('mouseleave', () => {
-            if (tooltipElement) tooltipElement.style.display = 'none';
-        });
+        const hideTooltip = () => {
+            if (tooltipElement && tooltipElement.dataset.user === targetUser) {
+                tooltipElement.style.display = 'none';
+            }
+        };
+
+        link.addEventListener('mouseleave', hideTooltip);
+        link.addEventListener('mousedown', hideTooltip); // Hide when navigating
         
         // Clear native title to prevent conflict
         if (link.title) link.setAttribute('data-sce-old-title', link.title);
@@ -396,9 +410,12 @@ function updateTooltipPosition(e) {
     let x = e.clientX + padding;
     let y = e.clientY + padding;
 
-    // Flip to left/top if overflow
-    if (x + 200 > window.innerWidth) x = e.clientX - tooltipElement.offsetWidth - padding;
-    if (y + 150 > window.innerHeight) y = e.clientY - tooltipElement.offsetHeight - padding;
+    // Use actual dimensions for overflow calculation
+    const tooltipWidth = tooltipElement.offsetWidth || 200;
+    const tooltipHeight = tooltipElement.offsetHeight || 150;
+
+    if (x + tooltipWidth > window.innerWidth) x = e.clientX - tooltipWidth - padding;
+    if (y + tooltipHeight > window.innerHeight) y = e.clientY - tooltipHeight - padding;
 
     tooltipElement.style.left = `${x}px`;
     tooltipElement.style.top = `${y}px`;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
-  "version": "0.7.0",
-  "version_name": "0.7.0 Beta",
+  "version": "0.7.1",
+  "version_name": "0.7.1 Beta",
   "name": "Steem Curation Extension",
   "description": "Provide supplemental information for curators on Steem/Condenser based web sites.",
   "icons": { 


### PR DESCRIPTION
- Resolve "stuck" tooltips by adding a mousedown listener for navigation and verifying the target user identity before hiding on mouseleave.
- Improve tooltip overflow logic by using dynamic element dimensions (offsetWidth/Height) instead of hardcoded values for reliable placement at screen edges.
- Refine account link selectors to specifically target post/comment authors and @-mentions in post bodies, preventing the overlay from appearing on non-essential links like voter lists or sidebars.
- Bump version to 0.7.1-beta and update CHANGELOG.md and README.md.